### PR TITLE
feat: enhance home layout with flash sale and product grids

### DIFF
--- a/src/app/features/home/components/flash-sale.component.html
+++ b/src/app/features/home/components/flash-sale.component.html
@@ -1,0 +1,15 @@
+<div class="flash-sale">
+  <div class="flash-header">
+    <h2>Flash Sale</h2>
+    <div class="countdown">
+      {{ time.hours }}:{{ time.minutes }}:{{ time.seconds }}
+    </div>
+  </div>
+  <div class="flash-grid">
+    <div class="flash-card" *ngFor="let product of products">
+      <img [src]="product.image" [alt]="product.title" />
+      <h3>{{ product.title }}</h3>
+      <p class="price">\${{ product.price }}</p>
+    </div>
+  </div>
+</div>

--- a/src/app/features/home/components/flash-sale.component.scss
+++ b/src/app/features/home/components/flash-sale.component.scss
@@ -1,0 +1,50 @@
+.flash-sale {
+  padding: 2rem 0;
+
+  .flash-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+
+    h2 {
+      margin: 0;
+    }
+
+    .countdown {
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--primary);
+    }
+  }
+
+  .flash-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+  }
+
+  .flash-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem;
+    text-align: center;
+    transition: transform 0.3s ease;
+
+    img {
+      width: 100%;
+      height: auto;
+      margin-bottom: 0.5rem;
+    }
+
+    &:hover {
+      transform: translateY(-4px);
+    }
+
+    .price {
+      color: var(--primary);
+      font-weight: 600;
+    }
+  }
+}

--- a/src/app/features/home/components/flash-sale.component.ts
+++ b/src/app/features/home/components/flash-sale.component.ts
@@ -1,0 +1,72 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface FlashProduct {
+  id: number;
+  title: string;
+  price: number;
+  image: string;
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-flash-sale',
+  imports: [CommonModule],
+  templateUrl: './flash-sale.component.html',
+  styleUrls: ['./flash-sale.component.scss'],
+})
+export class FlashSaleComponent implements OnInit, OnDestroy {
+  products: FlashProduct[] = [
+    {
+      id: 1,
+      title: 'Sneakers',
+      price: 39.99,
+      image: 'https://via.placeholder.com/150',
+    },
+    {
+      id: 2,
+      title: 'Headphones',
+      price: 19.99,
+      image: 'https://via.placeholder.com/150',
+    },
+    {
+      id: 3,
+      title: 'Watch',
+      price: 59.99,
+      image: 'https://via.placeholder.com/150',
+    },
+    {
+      id: 4,
+      title: 'Backpack',
+      price: 29.99,
+      image: 'https://via.placeholder.com/150',
+    },
+  ];
+
+  private endTime = Date.now() + 3600 * 1000;
+  time = { hours: '00', minutes: '00', seconds: '00' };
+  private intervalId?: number;
+
+  ngOnInit(): void {
+    this.updateTime();
+    this.intervalId = window.setInterval(() => this.updateTime(), 1000);
+  }
+
+  ngOnDestroy(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+    }
+  }
+
+  private updateTime(): void {
+    const diff = this.endTime - Date.now();
+    const h = Math.max(Math.floor(diff / 3600000), 0);
+    const m = Math.max(Math.floor((diff % 3600000) / 60000), 0);
+    const s = Math.max(Math.floor((diff % 60000) / 1000), 0);
+    this.time = {
+      hours: h.toString().padStart(2, '0'),
+      minutes: m.toString().padStart(2, '0'),
+      seconds: s.toString().padStart(2, '0'),
+    };
+  }
+}

--- a/src/app/features/home/components/product-grid.component.html
+++ b/src/app/features/home/components/product-grid.component.html
@@ -1,0 +1,10 @@
+<div class="product-grid">
+  <h2>Today's For You</h2>
+  <div class="grid">
+    <div class="product-card" *ngFor="let product of products">
+      <img [src]="product.image" [alt]="product.title" />
+      <h3>{{ product.title }}</h3>
+      <p class="price">\${{ product.price }}</p>
+    </div>
+  </div>
+</div>

--- a/src/app/features/home/components/product-grid.component.scss
+++ b/src/app/features/home/components/product-grid.component.scss
@@ -1,0 +1,38 @@
+.product-grid {
+  padding: 2rem 0;
+
+  h2 {
+    margin-bottom: 1rem;
+    text-align: center;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+  }
+
+  .product-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem;
+    text-align: center;
+    transition: transform 0.3s ease;
+
+    img {
+      width: 100%;
+      height: auto;
+      margin-bottom: 0.5rem;
+    }
+
+    &:hover {
+      transform: translateY(-4px);
+    }
+
+    .price {
+      color: var(--primary);
+      font-weight: 600;
+    }
+  }
+}

--- a/src/app/features/home/components/product-grid.component.ts
+++ b/src/app/features/home/components/product-grid.component.ts
@@ -1,0 +1,45 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface ProductItem {
+  id: number;
+  title: string;
+  price: number;
+  image: string;
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-product-grid',
+  imports: [CommonModule],
+  templateUrl: './product-grid.component.html',
+  styleUrls: ['./product-grid.component.scss'],
+})
+export class ProductGridComponent {
+  products: ProductItem[] = [
+    {
+      id: 1,
+      title: 'Phone',
+      price: 499,
+      image: 'https://via.placeholder.com/150',
+    },
+    {
+      id: 2,
+      title: 'Laptop',
+      price: 999,
+      image: 'https://via.placeholder.com/150',
+    },
+    {
+      id: 3,
+      title: 'Camera',
+      price: 299,
+      image: 'https://via.placeholder.com/150',
+    },
+    {
+      id: 4,
+      title: 'Tablet',
+      price: 199,
+      image: 'https://via.placeholder.com/150',
+    },
+  ];
+}

--- a/src/app/features/home/components/store-list.component.html
+++ b/src/app/features/home/components/store-list.component.html
@@ -1,0 +1,9 @@
+<div class="store-list">
+  <h2>Best Selling Store</h2>
+  <div class="stores">
+    <div class="store-banner" *ngFor="let store of stores">
+      <img [src]="store.image" [alt]="store.name" />
+      <span>{{ store.name }}</span>
+    </div>
+  </div>
+</div>

--- a/src/app/features/home/components/store-list.component.scss
+++ b/src/app/features/home/components/store-list.component.scss
@@ -1,0 +1,38 @@
+.store-list {
+  padding: 2rem 0;
+
+  h2 {
+    margin-bottom: 1rem;
+    text-align: center;
+  }
+
+  .stores {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+  }
+
+  .store-banner {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow: hidden;
+    text-align: center;
+    transition: transform 0.3s ease;
+
+    img {
+      width: 100%;
+      height: auto;
+    }
+
+    span {
+      display: block;
+      padding: 0.5rem;
+      font-weight: 600;
+    }
+
+    &:hover {
+      transform: translateY(-4px);
+    }
+  }
+}

--- a/src/app/features/home/components/store-list.component.ts
+++ b/src/app/features/home/components/store-list.component.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface Store {
+  id: number;
+  name: string;
+  image: string;
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-store-list',
+  imports: [CommonModule],
+  templateUrl: './store-list.component.html',
+  styleUrls: ['./store-list.component.scss'],
+})
+export class StoreListComponent {
+  stores: Store[] = [
+    { id: 1, name: 'Tech World', image: 'https://via.placeholder.com/300x100' },
+    {
+      id: 2,
+      name: 'Fashion Hub',
+      image: 'https://via.placeholder.com/300x100',
+    },
+    {
+      id: 3,
+      name: 'Gadget Galaxy',
+      image: 'https://via.placeholder.com/300x100',
+    },
+  ];
+}

--- a/src/app/features/home/pages/home.component.html
+++ b/src/app/features/home/pages/home.component.html
@@ -1,40 +1,18 @@
 <div class="home-container">
-  <header class="hero-section">
-    <div class="hero-content">
-      <h1 class="hero-title">Welcome to Mini E-Commerce!</h1>
-      <p class="hero-subtitle">Discover amazing products at unbeatable prices</p>
-      <div class="hero-actions">
+  <section class="promo-banner">
+    <div class="promo-content">
+      <h1>Big Summer Sale</h1>
+      <p>Up to 70% off selected items</p>
+      <div class="promo-actions">
         <button class="btn-primary" routerLink="/products">Shop Now</button>
         <button class="btn-secondary">Learn More</button>
       </div>
     </div>
-  </header>
-
-  <section class="features-section">
-    <div class="container">
-      <h2 class="section-title">Why Choose Us?</h2>
-      <div class="features-grid">
-        <div class="feature-card">
-          <div class="feature-icon">🚚</div>
-          <h3>Free Shipping</h3>
-          <p>Free delivery on orders over $50</p>
-        </div>
-        <div class="feature-card">
-          <div class="feature-icon">🔒</div>
-          <h3>Secure Payment</h3>
-          <p>100% secure payment processing</p>
-        </div>
-        <div class="feature-card">
-          <div class="feature-icon">↩️</div>
-          <h3>Easy Returns</h3>
-          <p>30-day hassle-free returns</p>
-        </div>
-        <div class="feature-card">
-          <div class="feature-icon">⭐</div>
-          <h3>Quality Products</h3>
-          <p>Curated selection of top-rated items</p>
-        </div>
-      </div>
-    </div>
   </section>
+
+  <app-flash-sale class="flash-sale-section"></app-flash-sale>
+
+  <app-product-grid class="products-section"></app-product-grid>
+
+  <app-store-list class="store-list-section"></app-store-list>
 </div>

--- a/src/app/features/home/pages/home.component.scss
+++ b/src/app/features/home/pages/home.component.scss
@@ -1,67 +1,39 @@
 .home-container {
-  min-height: 100vh;
   background: var(--bg);
-  transition: background-color 0.3s ease;
+  min-height: 100vh;
 }
 
-.hero-section {
+.promo-banner {
   background: var(--hero-bg);
   color: var(--hero-text);
-  padding: 4rem 2rem;
   text-align: center;
-  min-height: 60vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.3s ease;
-  border-bottom: 1px solid var(--border-color);
-}
+  padding: 4rem 2rem;
 
-.hero-content {
-  max-width: 800px;
-  margin: 0 auto;
-}
-
-.hero-title {
-  font-size: 3.5rem;
-  font-weight: 700;
-  margin-bottom: 1rem;
-  color: var(--hero-text);
-  text-shadow: 2px 2px 4px var(--shadow);
-  animation: fadeInUp 1s ease-out;
-  transition: all 0.3s ease;
-
-  @media (max-width: 768px) {
-    font-size: 2.5rem;
+  .promo-content {
+    max-width: 800px;
+    margin: 0 auto;
   }
 
-  @media (max-width: 480px) {
-    font-size: 2rem;
+  h1 {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+  }
+
+  p {
+    font-size: 1.25rem;
+    margin-bottom: 2rem;
+  }
+
+  .promo-actions {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
   }
 }
 
-.hero-subtitle {
-  font-size: 1.25rem;
-  margin-bottom: 2rem;
-  color: var(--hero-text);
-  opacity: 0.8;
-  animation: fadeInUp 1s ease-out 0.2s both;
-  transition: all 0.3s ease;
-
-  @media (max-width: 768px) {
-    font-size: 1.1rem;
-  }
-}
-
-.hero-actions {
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
-  flex-wrap: wrap;
-  animation: fadeInUp 1s ease-out 0.4s both;
-}
-
-.btn-primary, .btn-secondary {
+.btn-primary,
+.btn-secondary {
   padding: 0.875rem 2rem;
   border: none;
   border-radius: 50px;
@@ -76,13 +48,11 @@
 
 .btn-primary {
   background: #ff6b6b;
-  color: white;
-  box-shadow: 0 4px 15px rgba(255, 107, 107, 0.3);
+  color: #fff;
 
   &:hover {
     background: #ff5252;
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(255, 107, 107, 0.4);
   }
 }
 
@@ -90,7 +60,6 @@
   background: transparent;
   color: var(--hero-text);
   border: 2px solid var(--hero-text);
-  transition: all 0.3s ease;
 
   &:hover {
     background: var(--hero-text);
@@ -99,102 +68,60 @@
   }
 }
 
-.features-section {
-  padding: 4rem 2rem;
-  background: var(--bg-secondary);
-  transition: background-color 0.3s ease;
+.flash-sale-section,
+.products-section,
+.store-list-section {
+  padding: 2rem 0;
 }
 
-.container {
-  max-width: 1200px;
-  margin: 0 auto;
-}
-
-.section-title {
-  text-align: center;
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: var(--text);
-  margin-bottom: 3rem;
-  transition: color 0.3s ease;
-
-  @media (max-width: 768px) {
-    font-size: 2rem;
-  }
-}
-
-.features-grid {
+::ng-deep .flash-grid,
+::ng-deep .grid,
+::ng-deep .stores {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 2rem;
-  margin-top: 2rem;
+  gap: 1rem;
 }
 
-.feature-card {
+::ng-deep .flash-grid,
+::ng-deep .grid {
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+::ng-deep .stores {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+::ng-deep .flash-card,
+::ng-deep .product-card,
+::ng-deep .store-banner {
   background: var(--card-bg);
-  padding: 2rem;
-  border-radius: 16px;
-  text-align: center;
   border: 1px solid var(--border-color);
-  box-shadow: 0 4px 20px var(--shadow);
-  transition: all 0.3s ease;
-
-  &:hover {
-    transform: translateY(-8px);
-    box-shadow: 0 8px 30px var(--shadow-hover);
-  }
-
-  h3 {
-    color: var(--text);
-    font-size: 1.25rem;
-    font-weight: 600;
-    margin: 1rem 0 0.5rem 0;
-    transition: color 0.3s ease;
-  }
-
-  p {
-    color: var(--text-secondary);
-    font-size: 0.95rem;
-    line-height: 1.5;
-    margin: 0;
-    transition: color 0.3s ease;
-  }
+  border-radius: 8px;
+  text-align: center;
+  transition: transform 0.3s ease;
 }
 
-.feature-icon {
-  font-size: 3rem;
-  margin-bottom: 1rem;
-  display: block;
+::ng-deep .flash-card:hover,
+::ng-deep .product-card:hover,
+::ng-deep .store-banner:hover {
+  transform: translateY(-4px);
+}
+
+::ng-deep .countdown {
+  font-size: 1.25rem;
+  font-weight: 600;
   color: var(--primary);
-  transition: color 0.3s ease;
-}
-
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
 }
 
 @media (max-width: 768px) {
-  .hero-section {
+  .promo-banner {
     padding: 3rem 1rem;
-  }
-  
-  .features-section {
-    padding: 3rem 1rem;
-  }
-  
-  .hero-actions {
-    flex-direction: column;
-    align-items: center;
-  }
-  
-  .btn-primary, .btn-secondary {
-    width: 200px;
+
+    h1 {
+      font-size: 2.25rem;
+    }
+
+    p {
+      font-size: 1.1rem;
+    }
   }
 }

--- a/src/app/features/home/pages/home.component.ts
+++ b/src/app/features/home/pages/home.component.ts
@@ -1,11 +1,19 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { FlashSaleComponent } from '../components/flash-sale.component';
+import { ProductGridComponent } from '../components/product-grid.component';
+import { StoreListComponent } from '../components/store-list.component';
 
 @Component({
   standalone: true,
   selector: 'app-home',
-  imports: [RouterLink],
+  imports: [
+    RouterLink,
+    FlashSaleComponent,
+    ProductGridComponent,
+    StoreListComponent,
+  ],
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.scss']
+  styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent {}


### PR DESCRIPTION
## Summary
- replace home layout with hero banner, flash sale carousel, product grid, and store list
- add helper components for flash sale, product grid, and store list
- extend home styles for responsive grids, timers, and hover effects

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68baa49f0dcc8328bd8c0df6d819f761