### PR TITLE
feat: add site footer component

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,2 +1,3 @@
 <app-navbar />
 <router-outlet />
+<app-footer />

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,10 +1,11 @@
 import { Component, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { NavbarComponent } from './shared/components/navbar/navbar.component';
+import { FooterComponent } from './shared/components/footer/footer.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, NavbarComponent],
+  imports: [RouterOutlet, NavbarComponent, FooterComponent],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })

--- a/src/app/shared/components/footer/footer.component.html
+++ b/src/app/shared/components/footer/footer.component.html
@@ -1,0 +1,27 @@
+<footer class="footer">
+  <div class="footer-content">
+    <div class="footer-section">
+      <h3>Links</h3>
+      <a routerLink="/">Home</a>
+      <a routerLink="/products">Products</a>
+      <a routerLink="/cart">Cart</a>
+      <a routerLink="/wishlist">Wishlist</a>
+    </div>
+    <div class="footer-section">
+      <h3>Contact</h3>
+      <p>Email: support@example.com</p>
+      <p>Phone: +1 (555) 123-4567</p>
+    </div>
+    <div class="footer-section">
+      <h3>Follow Us</h3>
+      <div class="social-icons">
+        <a href="#" aria-label="Facebook">📘</a>
+        <a href="#" aria-label="Twitter">🐦</a>
+        <a href="#" aria-label="Instagram">📸</a>
+      </div>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <p>&copy; {{ currentYear }} mini-ecommerce</p>
+  </div>
+</footer>

--- a/src/app/shared/components/footer/footer.component.scss
+++ b/src/app/shared/components/footer/footer.component.scss
@@ -1,0 +1,58 @@
+.footer {
+  background: var(--navbar-bg);
+  color: var(--navbar-text);
+  padding: 2rem 1rem;
+  margin-top: 2rem;
+
+  .footer-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  h3 {
+    margin-bottom: 1rem;
+  }
+
+  a {
+    color: var(--navbar-text);
+    text-decoration: none;
+    margin-bottom: 0.5rem;
+    display: block;
+
+    &:hover {
+      color: var(--primary);
+    }
+  }
+
+  .social-icons {
+    display: flex;
+    gap: 0.5rem;
+
+    a {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      background: var(--bg-secondary);
+      color: var(--navbar-bg);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background 0.3s ease, color 0.3s ease;
+
+      &:hover {
+        background: var(--primary);
+        color: #fff;
+      }
+    }
+  }
+
+  .footer-bottom {
+    text-align: center;
+    margin-top: 2rem;
+    font-size: 0.875rem;
+    color: var(--text-muted);
+  }
+}

--- a/src/app/shared/components/footer/footer.component.ts
+++ b/src/app/shared/components/footer/footer.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  standalone: true,
+  selector: 'app-footer',
+  imports: [CommonModule, RouterLink],
+  templateUrl: './footer.component.html',
+  styleUrls: ['./footer.component.scss']
+})
+export class FooterComponent {
+  readonly currentYear = new Date().getFullYear();
+}


### PR DESCRIPTION
## Summary
- add footer component with quick links, contact details, and social icons
- integrate footer into root layout
- style footer with theme-aware variables and responsive grid

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68baa6afa81c8328b0e34245032e05bf